### PR TITLE
NOP any print in ReadmeCodeSpecs to prevent CI from crashing

### DIFF
--- a/SwiftDailyAPITests/Specs/ReadmeCodeSpecs.swift
+++ b/SwiftDailyAPITests/Specs/ReadmeCodeSpecs.swift
@@ -10,6 +10,11 @@ import Quick
 import Nimble
 import SwiftDailyAPI
 
+private func print() {
+  // nop
+  // prevent CI from crashing
+}
+
 class ReadmeCodeSpecs: QuickSpec {
   override func spec() {
     describe("Code in README.md") {


### PR DESCRIPTION
Crash log: `invalid byte sequence in UTF-8`

https://travis-ci.org/NicholasTD07/SwiftDailyAPI/builds/102064883
